### PR TITLE
Remove agency from top-level Realm objects

### DIFF
--- a/app/src/main/java/org/wildaid/ofish/data/RealmDataSource.kt
+++ b/app/src/main/java/org/wildaid/ofish/data/RealmDataSource.kt
@@ -110,7 +110,6 @@ class RealmDataSource {
     fun saveOnDutyChange(onDuty: Boolean) {
         realm.executeTransaction {
             realm.copyToRealm(DutyChange().apply {
-                agency = currentOfficer.agency
                 this.user = User().apply {
                     name = Name().apply {
                         first = currentOfficer.firstName

--- a/app/src/main/java/org/wildaid/ofish/data/report/DutyChange.kt
+++ b/app/src/main/java/org/wildaid/ofish/data/report/DutyChange.kt
@@ -14,5 +14,4 @@ open class DutyChange : RealmObject() {
     var user: User? = User()
     var date: Date = Date()
     var status: String = ""
-    var agency = ""
 }

--- a/app/src/main/java/org/wildaid/ofish/data/report/Photo.kt
+++ b/app/src/main/java/org/wildaid/ofish/data/report/Photo.kt
@@ -9,7 +9,6 @@ import java.util.Date
 open class Photo : RealmObject() {
     @PrimaryKey
     var _id: ObjectId = ObjectId.get()
-    var agency = ""
     var thumbNail: ByteArray? = null
     var picture: ByteArray? = null
     var pictureURL: String = ""

--- a/app/src/main/java/org/wildaid/ofish/data/report/Report.kt
+++ b/app/src/main/java/org/wildaid/ofish/data/report/Report.kt
@@ -12,7 +12,6 @@ import org.bson.types.ObjectId
 open class Report : RealmObject() {
     @PrimaryKey
     var _id: ObjectId = ObjectId.get()
-    var agency = ""
     var reportingOfficer: User? = User()
     var timestamp: Date = Date()
     var location: Location? = Location()

--- a/app/src/main/java/org/wildaid/ofish/ui/activity/ActivitiesViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/activity/ActivitiesViewModel.kt
@@ -136,7 +136,6 @@ class ActivitiesViewModel(val repository: Repository) : ViewModel() {
     private fun createPhoto(imageUri: Uri): PhotoItem {
         return PhotoItem(
             Photo().apply {
-                agency = repository.getCurrentOfficer().agency
                 referencingReportID = currentReport._id.toString()
             },
             imageUri

--- a/app/src/main/java/org/wildaid/ofish/ui/catches/CatchViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/catches/CatchViewModel.kt
@@ -120,7 +120,6 @@ class CatchViewModel(
     private fun createPhoto(imageUri: Uri): PhotoItem {
         return PhotoItem(
             Photo().apply {
-                agency = repository.getCurrentOfficer().agency
                 referencingReportID = currentReport._id.toString()
             },
             imageUri

--- a/app/src/main/java/org/wildaid/ofish/ui/createreport/CreateReportViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/createreport/CreateReportViewModel.kt
@@ -20,7 +20,6 @@ class CreateReportViewModel(val repository: Repository) : ViewModel() {
 
         reportPhotos = mutableListOf()
         report = Report().apply {
-            agency = officer.agency
             reportingOfficer?.apply {
                 email = officer.email
                 name?.apply {

--- a/app/src/main/java/org/wildaid/ofish/ui/crew/CrewViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/crew/CrewViewModel.kt
@@ -202,7 +202,6 @@ class CrewViewModel(
 
     private fun createPhoto(): Photo {
         return Photo().apply {
-            agency = repository.getCurrentOfficer().agency
             referencingReportID = currentReport._id.toString()
         }
     }

--- a/app/src/main/java/org/wildaid/ofish/ui/notes/NotesViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/notes/NotesViewModel.kt
@@ -83,7 +83,6 @@ class NotesViewModel(
     private fun createPhoto(imageUri: Uri): PhotoItem {
         return PhotoItem(
             Photo().apply {
-                agency = repository.getCurrentOfficer().agency
                 referencingReportID = currentReport._id.toString()
             },
             imageUri

--- a/app/src/main/java/org/wildaid/ofish/ui/vessel/VesselViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/vessel/VesselViewModel.kt
@@ -255,7 +255,6 @@ class VesselViewModel(val repository: Repository) : ViewModel() {
     private fun createPhoto(imageUri: Uri): PhotoItem {
         return PhotoItem(
             Photo().apply {
-                agency = repository.getCurrentOfficer().agency
                 referencingReportID = currentReport._id.toString()
             },
             imageUri

--- a/app/src/main/java/org/wildaid/ofish/ui/violation/ViolationViewModel.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/violation/ViolationViewModel.kt
@@ -129,7 +129,6 @@ class ViolationViewModel(val repository: Repository,
 
     private fun createPhoto(): Photo {
         return Photo().apply {
-            agency = repository.getCurrentOfficer().agency
             referencingReportID = currentReport._id.toString()
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-        classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.4"
+        classpath "io.realm:realm-gradle-plugin:10.0.0-BETA.5"
 
         classpath 'com.google.gms:google-services:4.3.3'
 


### PR DESCRIPTION
Realm has been updated such that there's no longer a need to manually include the partition name in the top-level Realm Objects - Realm will automatically add it before writing the document to Atlas.

[-] Remove `agency` from Photo, Report and DutyChange Objects
[-] Up-version to Beta 5 Realm SDK

Fixes #109 