### PR TITLE
fix: change android input type to use numeric keyboard by default

### DIFF
--- a/app/src/main/res/layout/item_edit_vessel_ems.xml
+++ b/app/src/main/res/layout/item_edit_vessel_ems.xml
@@ -118,6 +118,7 @@
                     android:id="@+id/vessel_edit_ems_register_number"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:inputType="number"
                     android:hint="@string/registry_number"
                     android:imeOptions="actionNext"
                     android:nextFocusDown="@id/delivery_location"


### PR DESCRIPTION
## Related Issue

Fixes #272

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 

![Screenshot_1601642116](https://user-images.githubusercontent.com/9157911/94924967-176ac700-0484-11eb-9797-4ebd3c09873a.png)



