### PR TITLE
Dark Mode to for Simple Search Page

### DIFF
--- a/app/src/main/res/drawable/selector_adapter_item.xml
+++ b/app/src/main/res/drawable/selector_adapter_item.xml
@@ -4,10 +4,10 @@
     <item>
         <selector>
             <item
-                android:drawable="@android:color/darker_gray"
+                android:drawable="@color/grey_1"
                 android:state_pressed="true" />
 
-            <item android:drawable="@color/white" />
+            <item android:drawable="@color/background_menu" />
         </selector>
     </item>
 </ripple>

--- a/app/src/main/res/layout/item_search_simple.xml
+++ b/app/src/main/res/layout/item_search_simple.xml
@@ -10,6 +10,7 @@
         android:id="@+id/item_title"
         android:layout_width="match_parent"
         android:layout_height="58dp"
+        android:textColor="@color/header_color"
         android:background="@drawable/selector_adapter_item"
         android:clickable="true"
         android:gravity="center_vertical"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -7,6 +7,7 @@
 
     <color name="background_card">#1C1C1E</color>
     <color name="background_screen_with_cards">#000000</color>
+    <color name="background_menu">#000000</color>
     <color name="map_coordinates_background">#B4FFFFFF</color>
 
     <color name="divider">#CCC7C7</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
 
     <color name="background_card">#FFFFFF</color>
     <color name="background_screen_with_cards">#F9FAFA</color>
+    <color name="background_menu">#FFFFFF</color>
     <color name="map_coordinates_background">#B4FFFFFF</color>
 
     <color name="divider">#CCC7C7</color>
@@ -43,7 +44,7 @@
     <color name="search_icon_color">#8A000000</color>
     <color name="black_1">#000000</color>
     <color name="black_2">#1C1C1E</color>
-    <color name="grey_1">#979797</color>
+    <color name="grey_1">#666666</color>
     <color name="grey_8">#F9FAFA</color>
 
     <color name="selected_tab">#0A4074</color>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Dark Mode to for Simple Search Page (Pull-Down Menus)
Fixes https://github.com/WildAid/o-fish-android/issues/380

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 
<img width="200" src="https://user-images.githubusercontent.com/6845983/95655140-7046f900-0b2f-11eb-8cc2-40528c91d91b.png">  

<img width="200" src="https://user-images.githubusercontent.com/6845983/95655134-6b824500-0b2f-11eb-9bfd-2c490f7596ae.png">  <img width="200" src="https://user-images.githubusercontent.com/6845983/95655139-6fae6280-0b2f-11eb-8022-6b697fbfd746.png">  <img width="200" src="https://user-images.githubusercontent.com/6845983/95655137-6de49f00-0b2f-11eb-8b04-0dfdd0126d57.png">