### PR TITLE
Fixed dark mode - Search page

### DIFF
--- a/app/src/main/res/drawable/selector_adapter_item.xml
+++ b/app/src/main/res/drawable/selector_adapter_item.xml
@@ -7,7 +7,7 @@
                 android:drawable="@android:color/darker_gray"
                 android:state_pressed="true" />
 
-            <item android:drawable="@color/white" />
+            <item android:drawable="@color/search_background" />
         </selector>
     </item>
 </ripple>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -36,8 +36,8 @@
     <color name="tabs_amber">#E17000</color>
     <color name="captain_background">#E7ECF1</color>
     <color name="record_second">#979797</color>
-    <color name="light_grey_background">#F7F7F7</color>
-    <color name="grey_text">#818181</color>
+    <color name="light_grey_background">#2C2C2E</color>
+    <color name="grey_text">#CBCBCB</color>
     <color name="search_record_background">#FFFFFF</color>
     <color name="status_bar_blue">#002548</color>
     <color name="search_icon_color">#8A000000</color>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes # https://github.com/WildAid/o-fish-android/issues/373

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 
The colors that were changed were only being used in the components that were fixed for dark mode.


* **Optional: Add any relevant screenshots here** 
![image](https://user-images.githubusercontent.com/13731530/95916160-dba9f880-0dc5-11eb-9670-815c33557047.png)
![image](https://user-images.githubusercontent.com/13731530/95916221-f2e8e600-0dc5-11eb-9a0f-7f52c0b4889e.png)



