### PR TITLE
Clicking on notification opens the profile section of the app

### DIFF
--- a/app/src/main/java/org/wildaid/ofish/app/OnDutyAlarmReminder.kt
+++ b/app/src/main/java/org/wildaid/ofish/app/OnDutyAlarmReminder.kt
@@ -3,20 +3,31 @@ package org.wildaid.ofish.app
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.navigation.NavDeepLinkBuilder
 import org.wildaid.ofish.R
+import org.wildaid.ofish.ui.home.HomeActivity
 
 private const val NOTIFICATION_ID = 119
 
 class OnDutyAlarmReminder : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
+        val pendingIntent = NavDeepLinkBuilder(context)
+            .setComponentName(HomeActivity::class.java)
+            .setGraph(R.navigation.home_navigation)
+            .setDestination(R.id.profileFragment)
+            .setArguments(Bundle())
+            .createPendingIntent()
+
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(context.getString(R.string.app_name))
             .setContentText("Are you still on duty?")
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
 
         with(NotificationManagerCompat.from(context)) {
             notify(NOTIFICATION_ID, builder.build())

--- a/app/src/main/java/org/wildaid/ofish/ui/home/HomeActivity.kt
+++ b/app/src/main/java/org/wildaid/ofish/ui/home/HomeActivity.kt
@@ -1,6 +1,7 @@
 package org.wildaid.ofish.ui.home
 
 import android.app.AlarmManager
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.SearchManager
 import android.content.Context
@@ -41,6 +42,7 @@ class HomeActivity : AppCompatActivity(R.layout.activity_home) {
             }
         })
         activityViewModel.timerLiveData.observe(this, EventObserver(::setOrCancelTimer))
+        clearAllNotifications()
     }
 
     private fun navigateToPatrolSummary() {
@@ -109,5 +111,10 @@ class HomeActivity : AppCompatActivity(R.layout.activity_home) {
         } else {
             alarmManager?.cancel(alarmIntent)
         }
+    }
+
+    private fun clearAllNotifications() {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancelAll()
     }
 }


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #399 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 
On clicking the notification the user is taken to the profile section of the app, where he can set himself not at sea


* **Optional: Add any relevant screenshots here** 



