### PR TITLE
type: Toggle switch in light mode needs a green background #427 fixed

### DIFF
--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -9,6 +9,7 @@
         <item name="actionOverflowButtonStyle">@style/OverflowButton</item>
         <item name="searchViewStyle">@style/ToolbarSearchViewStyle</item>
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
+        <item name="colorControlActivated">@color/green_dark</item>
     </style>
 
     <style name="OverflowButton" parent="Widget.MaterialComponents.PopupMenu.Overflow">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="tab_inactive">#979797</color>
     <color name="white">#FFFFFF</color>
     <color name="green">#008537</color>
+    <color name="green_dark">#00B34A</color>
     <color name="light_green">#ECF4EF</color>
     <color name="green_background">#DEEFE5</color>
     <color name="green_text">#006128</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,10 +53,6 @@
         <item name="cornerSize">50%</item>
     </style>
 
-    <style name="SwitchTheme" parent="Theme.AppCompat.Light">
-        <item name="android:colorControlActivated"></item>
-    </style>
-
     <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline5">
         <item name="android:textColor">@android:color/black</item>
         <item name="android:textSize">20sp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,7 +9,7 @@
         <item name="actionOverflowButtonStyle">@style/OverflowButton</item>
         <item name="searchViewStyle">@style/ToolbarSearchViewStyle</item>
         <item name="textInputStyle">@style/TextInputLayoutStyle</item>
-            <item name="colorControlActivated">#FFF</item>
+        <item name="colorControlActivated">@color/green_dark</item>
     </style>
 
     <style name="OverflowButton" parent="Widget.MaterialComponents.PopupMenu.Overflow">
@@ -51,6 +51,10 @@
     <style name="circleImageView" parent="">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
+    </style>
+
+    <style name="SwitchTheme" parent="Theme.AppCompat.Light">
+        <item name="android:colorControlActivated"></item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline5">


### PR DESCRIPTION

Fixes #427 

Fixed toggle white button issue. Now it will be green for both dark and light mode when enabled.



![image](https://user-images.githubusercontent.com/46865638/96736707-82038880-13da-11eb-970d-84100a10ca0a.png)




