### PR TITLE
fix: adds content description for the image view for screen reader support

### DIFF
--- a/app/src/main/res/layout/fragment_vessel.xml
+++ b/app/src/main/res/layout/fragment_vessel.xml
@@ -67,7 +67,8 @@
                         android:src="@drawable/ic_add_attachment"
                         android:tint="@color/dark_grey"
                         app:layout_constraintEnd_toEndOf="@id/vessel_information_title"
-                        app:layout_constraintTop_toTopOf="@id/vessel_information_title" />
+                        app:layout_constraintTop_toTopOf="@id/vessel_information_title"
+                        android:contentDescription="@string/add_an_attachment" />
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/vessel_edit_info"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,6 +10,7 @@
     <string name="vessel_name">Nom du vaisseau</string>
     <string name="vessel">Vaisseau</string>
     <string name="vessel_information">Détails du vaisseau</string>
+    <string name="add_an_attachment">Ajouter des pièces jointes</string>
     <string name="permit_number">Numéro de permis</string>
     <string name="home_port">Port de rattachement</string>
     <string name="last_delivery">Dernière livraison</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="vessel_name">Nom du vaisseau</string>
     <string name="vessel">Vaisseau</string>
     <string name="vessel_information">Détails du vaisseau</string>
-    <string name="add_an_attachment">Ajouter des pièces jointes</string>
+    <string name="add_an_attachment">Ajouter une note ou une photo</string>
     <string name="permit_number">Numéro de permis</string>
     <string name="home_port">Port de rattachement</string>
     <string name="last_delivery">Dernière livraison</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -10,7 +10,7 @@
     <string name="vessel_name">Назва судна</string>
     <string name="vessel">Судно</string>
     <string name="vessel_information">Інформація про судно</string>
-    <string name="add_an_attachment">Додати вкладення</string>
+    <string name="add_an_attachment">додати примітку або фото</string>
     <string name="permit_number">Номер дозволу</string>
     <string name="home_port">Порт приписки</string>
     <string name="last_delivery">Остання поставка</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -10,6 +10,7 @@
     <string name="vessel_name">Назва судна</string>
     <string name="vessel">Судно</string>
     <string name="vessel_information">Інформація про судно</string>
+    <string name="add_an_attachment">Додати вкладення</string>
     <string name="permit_number">Номер дозволу</string>
     <string name="home_port">Порт приписки</string>
     <string name="last_delivery">Остання поставка</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="vessel_name">Vessel Name</string>
     <string name="vessel">Vessel</string>
     <string name="vessel_information">Vessel Information</string>
+    <string name="add_an_attachment">Add Attachments</string>
     <string name="permit_number">Permit Number</string>
     <string name="home_port">Home Port</string>
     <string name="last_delivery">Last Delivery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="vessel_name">Vessel Name</string>
     <string name="vessel">Vessel</string>
     <string name="vessel_information">Vessel Information</string>
-    <string name="add_an_attachment">Add Attachments</string>
+    <string name="add_an_attachment">Add Photo or Note</string>
     <string name="permit_number">Permit Number</string>
     <string name="home_port">Home Port</string>
     <string name="last_delivery">Last Delivery</string>


### PR DESCRIPTION
- Adds `contentDescription` for the attachment icon image view for screen reader support
- Adds translations for the string value in French & Ukrainian

## Related Issue

Fixes #423

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 

I added translations for the text, 'Add Attachments' in French and Ukrainian using Google Translate. Please validate the translations. 

* **Optional: Add any relevant screenshots here** 



